### PR TITLE
upgrade buf-setup-action and not pin to a buf version in param

### DIFF
--- a/.github/workflows/buf.yaml
+++ b/.github/workflows/buf.yaml
@@ -11,9 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: bufbuild/buf-setup-action@v1
-        with:
-          version: 1.6.0
+      - uses: bufbuild/buf-setup-action@@v1.9.0
       - uses: bufbuild/buf-lint-action@v1.0.2
         with:
           buf_token: ${{ secrets.BUF_TOKEN }}
@@ -21,9 +19,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: bufbuild/buf-setup-action@v1
-        with:
-          version: 1.6.0
+      - uses: bufbuild/buf-setup-action@@v1.9.0
       - uses: bufbuild/buf-breaking-action@v1.1.1
         with:
           against: 'https://github.com/bufbuild/connect-demo.git#branch=main'
@@ -35,9 +31,7 @@ jobs:
       - breaking
     steps:
       - uses: actions/checkout@v3
-      - uses: bufbuild/buf-setup-action@v1
-        with:
-          version: 1.6.0
+      - uses: bufbuild/buf-setup-action@@v1.9.0
       - uses: bufbuild/buf-push-action@v1.0.1
         with:
           input: 'proto'


### PR DESCRIPTION
the changes in #52 is not picked up by `buf-push-action` because the `buf-setup-action` is pinned to buf 1.6.0 using `with version`. this changed to pin the action instead, which can be updated by dependabot
