### PR TITLE
Automate adding issues and PRs to project board

### DIFF
--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -1,0 +1,25 @@
+name: Add issues and PRs to project
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get GitHub app token
+        uses: actions/create-github-app-token@v1
+        id: app_token
+        with:
+          app-id: ${{ secrets.CONNECT_EXPORT_APP_ID }}
+          private-key: ${{ secrets.CONNECT_EXPORT_APP_KEY }}
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/connectrpc/projects/1
+          github-token: ${{ steps.app_token.outputs.token }}

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -4,9 +4,12 @@ on:
   issues:
     types:
       - opened
+      - reopened
+      - transferred
   pull_request:
     types:
       - opened
+      - reopened
 
 jobs:
   add-to-project:


### PR DESCRIPTION
This introduces automation for adding issues and PRs to an org-wide project board. The goal is to have a clear view into incoming issues/PRs so that we know none can fall through the cracks.