### PR TITLE
Bump Go version to 1.22

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.20.x
+          go-version: 1.22.x
       - name: make-test
         run: make test && make checkgenerate
       - name: make-lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.20.x
       - name: make-test
         run: make test && make checkgenerate
       - name: make-lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: make-test
         run: make test && make checkgenerate
       - name: make-lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.21.x
       - name: make-test
         run: make test && make checkgenerate
       - name: make-lint

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 The Connect Authors
+   Copyright 2022-2024 The Connect Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ MAKEFLAGS += --no-print-directory
 BIN=$(abspath .tmp/bin)
 export PATH := $(BIN):$(PATH)
 export GOBIN := $(abspath $(BIN))
-COPYRIGHT_YEARS := 2022-2023
+COPYRIGHT_YEARS := 2022-2024
 LICENSE_IGNORE := --ignore /testdata/
 # Set to use a different compiler. For example, `GO=go1.18rc1 make test`.
 GO ?= go
@@ -68,15 +68,15 @@ checkgenerate:
 
 $(BIN)/buf: Makefile
 	@mkdir -p $(@D)
-	$(GO) install github.com/bufbuild/buf/cmd/buf@v1.26.1
+	$(GO) install github.com/bufbuild/buf/cmd/buf@v1.29.0
 
 $(BIN)/license-header: Makefile
 	@mkdir -p $(@D)
-	$(GO) install github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@v1.26.1
+	$(GO) install github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@v1.29.0
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.1
+	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.2
 
 $(BIN)/protoc-gen-go: Makefile
 	@mkdir -p $(@D)

--- a/cmd/demoserver/main.go
+++ b/cmd/demoserver/main.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Connect Authors
+// Copyright 2022-2024 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/demoserver/main.go
+++ b/cmd/demoserver/main.go
@@ -53,7 +53,7 @@ func (e *elizaServer) Say(
 	_ context.Context,
 	req *connect.Request[elizav1.SayRequest],
 ) (*connect.Response[elizav1.SayResponse], error) {
-	reply, _ := eliza.Reply(req.Msg.Sentence) // ignore end-of-conversation detection
+	reply, _ := eliza.Reply(req.Msg.GetSentence()) // ignore end-of-conversation detection
 	return connect.NewResponse(&elizav1.SayResponse{
 		Sentence: reply,
 	}), nil
@@ -73,7 +73,7 @@ func (e *elizaServer) Converse(
 		} else if err != nil {
 			return fmt.Errorf("receive request: %w", err)
 		}
-		reply, endSession := eliza.Reply(request.Sentence)
+		reply, endSession := eliza.Reply(request.GetSentence())
 		if err := stream.Send(&elizav1.ConverseResponse{Sentence: reply}); err != nil {
 			return fmt.Errorf("send response: %w", err)
 		}
@@ -88,7 +88,7 @@ func (e *elizaServer) Introduce(
 	req *connect.Request[elizav1.IntroduceRequest],
 	stream *connect.ServerStream[elizav1.IntroduceResponse],
 ) error {
-	name := req.Msg.Name
+	name := req.Msg.GetName()
 	if name == "" {
 		name = "Anonymous User"
 	}
@@ -125,7 +125,7 @@ func newCORS() *cors.Cors {
 			http.MethodPatch,
 			http.MethodDelete,
 		},
-		AllowOriginFunc: func(origin string) bool {
+		AllowOriginFunc: func(_ string) bool {
 			// Allow all origins, which effectively disables CORS.
 			return true
 		},

--- a/cmd/demoserver/main_test.go
+++ b/cmd/demoserver/main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Connect Authors
+// Copyright 2022-2024 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/demoserver/main_test.go
+++ b/cmd/demoserver/main_test.go
@@ -73,11 +73,11 @@ func TestElizaServer(t *testing.T) {
 				defer wg.Done()
 				for _, sentence := range sendValues {
 					err := stream.Send(&elizav1.ConverseRequest{Sentence: sentence})
-					if assert.ErrorContainsf(t, err, `failed for string sentence: "%s"`, sentence) { 
+					if !assert.NoError(t, err, `failed for string sentence: "%s"`, sentence) {
 						break
 					}
 				}
-				assert.NoError(t, stream.CloseRequest()) 
+				assert.NoError(t, stream.CloseRequest())
 			}()
 			go func() {
 				defer wg.Done()
@@ -92,7 +92,7 @@ func TestElizaServer(t *testing.T) {
 					assert.NotEmpty(t, msg.GetSentence())
 					receivedValues = append(receivedValues, msg.GetSentence())
 				}
-				assert.NoError(t, stream.CloseResponse()) 
+				assert.NoError(t, stream.CloseResponse())
 			}()
 			wg.Wait()
 			assert.Equal(t, len(receivedValues), len(sendValues))

--- a/cmd/demoserver/main_test.go
+++ b/cmd/demoserver/main_test.go
@@ -17,7 +17,6 @@ package main
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -59,8 +58,8 @@ func TestElizaServer(t *testing.T) {
 			result, err := client.Say(context.Background(), connect.NewRequest(&elizav1.SayRequest{
 				Sentence: "Hello",
 			}))
-			require.Nil(t, err)
-			assert.True(t, len(result.Msg.Sentence) > 0)
+			require.NoError(t, err)
+			assert.NotEmpty(t, result.Msg.GetSentence())
 		}
 	})
 	t.Run("converse", func(t *testing.T) {
@@ -74,9 +73,11 @@ func TestElizaServer(t *testing.T) {
 				defer wg.Done()
 				for _, sentence := range sendValues {
 					err := stream.Send(&elizav1.ConverseRequest{Sentence: sentence})
-					require.Nil(t, err, fmt.Sprintf(`failed for string sentence: "%s"`, sentence))
+					if assert.ErrorContainsf(t, err, `failed for string sentence: "%s"`, sentence) { 
+						break
+					}
 				}
-				require.Nil(t, stream.CloseRequest())
+				assert.NoError(t, stream.CloseRequest()) 
 			}()
 			go func() {
 				defer wg.Done()
@@ -85,11 +86,13 @@ func TestElizaServer(t *testing.T) {
 					if errors.Is(err, io.EOF) {
 						break
 					}
-					require.Nil(t, err)
-					assert.True(t, len(msg.Sentence) > 0)
-					receivedValues = append(receivedValues, msg.Sentence)
+					if !assert.NoError(t, err) {
+						break
+					}
+					assert.NotEmpty(t, msg.GetSentence())
+					receivedValues = append(receivedValues, msg.GetSentence())
 				}
-				require.Nil(t, stream.CloseResponse())
+				assert.NoError(t, stream.CloseResponse()) 
 			}()
 			wg.Wait()
 			assert.Equal(t, len(receivedValues), len(sendValues))
@@ -102,13 +105,13 @@ func TestElizaServer(t *testing.T) {
 				Name: "Ringo",
 			})
 			stream, err := client.Introduce(context.Background(), request)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			for stream.Receive() {
 				total++
 			}
-			assert.Nil(t, stream.Err())
-			assert.Nil(t, stream.Close())
-			assert.True(t, total > 0)
+			require.NoError(t, stream.Err())
+			require.NoError(t, stream.Close())
+			assert.Greater(t, total, 0)
 		}
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@
 // Users should clone the repo to explore the examples.
 module connect-examples-go
 
-go 1.18
+go 1.20
 
 require (
 	connectrpc.com/connect v1.14.0

--- a/internal/eliza/eliza.go
+++ b/internal/eliza/eliza.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Connect Authors
+// Copyright 2022-2024 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/eliza/eliza_test.go
+++ b/internal/eliza/eliza_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Connect Authors
+// Copyright 2022-2024 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/eliza/globals.go
+++ b/internal/eliza/globals.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Connect Authors
+// Copyright 2022-2024 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/gen/connectrpc/eliza/v1/eliza.pb.go
+++ b/internal/gen/connectrpc/eliza/v1/eliza.pb.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Connect Authors
+// Copyright 2022-2024 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/gen/connectrpc/eliza/v1/elizav1connect/eliza.connect.go
+++ b/internal/gen/connectrpc/eliza/v1/elizav1connect/eliza.connect.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Connect Authors
+// Copyright 2022-2024 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/proto/connectrpc/eliza/v1/eliza.proto
+++ b/proto/connectrpc/eliza/v1/eliza.proto
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Connect Authors
+// Copyright 2022-2024 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Bumps go version to 1.22 with the new min at 1.20. Also add LICENSE file updates along with a bump to buf and golanglint-ci. Fixes from lintci. Please see commit-by-commit.