### PR TITLE
Migrate to v2 config

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,12 +1,13 @@
-version: v1
+version: v2
 managed:
   enabled: true
-  go_package_prefix:
-    default: connect-examples-go/internal/gen
+  override:
+    - file_option: go_package_prefix
+      value: connect-examples-go/internal/gen
 plugins:
-  - name: go
+  - local: protoc-gen-go
     out: internal/gen
     opt: paths=source_relative
-  - name: connect-go
+  - local: protoc-gen-connect-go
     out: internal/gen
     opt: paths=source_relative

--- a/buf.work.yaml
+++ b/buf.work.yaml
@@ -1,3 +1,0 @@
-version: v1
-directories:
-  - proto

--- a/buf.yaml
+++ b/buf.yaml
@@ -5,13 +5,6 @@ modules:
 lint:
   use:
     - DEFAULT
-  except:
-    - FIELD_NOT_REQUIRED
-    - PACKAGE_NO_IMPORT_CYCLE
-  disallow_comment_ignores: true
 breaking:
   use:
     - FILE
-  except:
-    - EXTENSION_NO_DELETE
-    - FIELD_SAME_DEFAULT

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,0 +1,17 @@
+version: v2
+modules:
+  - path: proto
+    name: buf.build/connectrpc/eliza
+lint:
+  use:
+    - DEFAULT
+  except:
+    - FIELD_NOT_REQUIRED
+    - PACKAGE_NO_IMPORT_CYCLE
+  disallow_comment_ignores: true
+breaking:
+  use:
+    - FILE
+  except:
+    - EXTENSION_NO_DELETE
+    - FIELD_SAME_DEFAULT

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -1,8 +1,0 @@
-version: v1
-name: buf.build/connectrpc/eliza
-lint:
-  use:
-    - DEFAULT
-breaking:
-  use:
-    - FILE


### PR DESCRIPTION
I think the old configuration file is unfriendly to people looking for sample code